### PR TITLE
feat: add customizable QR generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,33 @@
-html
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Generador de QR Personalizado</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Generador de QR Personalizado</h1>
+    <form id="qr-form">
+      <label for="qr-text">Texto/URL</label>
+      <input type="text" id="qr-text" required />
+
+      <label for="qr-color">Color</label>
+      <input type="color" id="qr-color" value="#000000" />
+
+      <label for="qr-bg">Color de fondo</label>
+      <input type="color" id="qr-bg" value="#ffffff" />
+
+      <label for="qr-size">Tamaño (px)</label>
+      <input type="number" id="qr-size" min="100" max="500" value="200" />
+
+      <button type="submit">Generar QR</button>
+    </form>
+    <div id="qr-result"></div>
+    <h2>Historial</h2>
+    <div id="qr-history"></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,52 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('qr-form');
+  const result = document.getElementById('qr-result');
+  const historyDiv = document.getElementById('qr-history');
+  const HISTORY_KEY = 'qrHistory';
+
+  const history = JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
+  history.forEach(item => addHistoryItem(item));
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = document.getElementById('qr-text').value.trim();
+    const color = document.getElementById('qr-color').value.replace('#', '');
+    const bg = document.getElementById('qr-bg').value.replace('#', '');
+    const size = document.getElementById('qr-size').value;
+
+    if (!text) return;
+    if (history.some(h => h.text === text)) {
+      alert('El código ya existe en el historial');
+      return;
+    }
+
+    const url = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encodeURIComponent(text)}&color=${color}&bgcolor=${bg}`;
+
+    const img = document.createElement('img');
+    img.src = url;
+    img.alt = text;
+    result.innerHTML = '';
+    result.appendChild(img);
+
+    const entry = { text, color, bg, size, url, created: new Date().toISOString() };
+    history.push(entry);
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+    addHistoryItem(entry);
+  });
+
+  function addHistoryItem(item) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'history-item';
+
+    const img = document.createElement('img');
+    img.src = item.url || `https://api.qrserver.com/v1/create-qr-code/?size=100x100&data=${encodeURIComponent(item.text)}&color=${item.color}&bgcolor=${item.bg}`;
+    img.alt = item.text;
+    wrapper.appendChild(img);
+
+    const caption = document.createElement('p');
+    caption.textContent = item.text;
+    wrapper.appendChild(caption);
+
+    historyDiv.appendChild(wrapper);
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,54 @@
+body {
+  font-family: Arial, sans-serif;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  color: #333;
+}
+
+.container {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  max-width: 600px;
+  width: 100%;
+  margin-top: 40px;
+}
+
+form {
+  display: grid;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+#qr-result {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+#qr-history {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.history-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 12px;
+  width: 100px;
+}
+
+.history-item img {
+  width: 100px;
+  height: 100px;
+  object-fit: contain;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- create a decorative single-page app to generate QR codes with color, size, and background options
- store generated codes in browser history and prevent duplicates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e355ac0c483228f4a0a5ff8a8072d